### PR TITLE
Update Dockerfile to use bookworm-slim base images for consistency

### DIFF
--- a/src/server/Dockerfile.prod
+++ b/src/server/Dockerfile.prod
@@ -1,11 +1,11 @@
 # Production Dockerfile
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-amd64 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim-amd64 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy-amd64 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["talking-points.csproj", "./"]


### PR DESCRIPTION
Update Dockerfile to use bookworm-slim base images for consistency